### PR TITLE
Add: Beat Campaign Every 3 Days (Mythic Trick)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 config.sh
 adb
 .markdownlint.json
+.afkscript.tmp

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Since lately I've been adding quite a lot of new features and bug fixes, this RE
 As of now, the script is capable of completing the following inside the game:
 
 - Loot AFK chest
-- Fight the current campaign level
+- Fight the current campaign level (automatically fights every three days for Mythic Trick)
 - Collect Fast Rewards
 - Send Companion Points to friends
 - Auto Lend Mercenaries

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -572,7 +572,7 @@ function challengeBoss() {
         # Check for confirm to exit button
         getColor 715 1260
         if [ "$RGB" == "feffff" ]; then
-            input tap 60 1850 # Return
+            input tap 715 1260 # Confirm
             wait
         fi
     else

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1301,7 +1301,6 @@ fi
 switchTab "Campaign"
 if [ "$doLootAfkChest" == true ]; then lootAfkChest; fi
 if [ "$doChallengeBoss" == true ]; then challengeBoss; fi
-exit
 if [ "$doFastRewards" == true ]; then fastRewards; fi
 if [ "$doCollectFriendsAndMercenaries" == true ]; then collectFriendsAndMercenaries; fi
 if [ "$doLootAfkChest" == true ]; then lootAfkChest; fi

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -518,8 +518,9 @@ function challengeBoss() {
     fi
     sleep 2
 
-    # Finish battle if been 3 days
+    # Fight battle or not
     if [ "$forceFightCampaign" == "true" ]; then
+        # Fight in the campaign because of Mythic Trick
         echo "[INFO] Figthing in campaign because of Mythic Trick $maxCampaignFights time(s)."
         local COUNT=0
 
@@ -569,8 +570,8 @@ function challengeBoss() {
         wait
 
         # Check for confirm to exit button
-        getColor 450 1775
-        if [ "$RGB" != "cc9261" ]; then
+        getColor 715 1260
+        if [ "$RGB" == "feffff" ]; then
             input tap 60 1850 # Return
             wait
         fi

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -9,10 +9,12 @@ totalAmountOakRewards=3
 # Do not modify
 RGB=00000000
 oakRes=0
+forceFightCampaign=false
 if [ $# -gt 0 ]; then
     SCREENSHOTLOCATION="/$1/scripts/afk-arena/screen.dump"
     # SCREENSHOTLOCATION="/$1/scripts/afk-arena/screen.png"
     source /$1/scripts/afk-arena/config.sh
+	forceFightCampaign=$2
 else
     SCREENSHOTLOCATION="/storage/emulated/0/scripts/afk-arena/screen.dump"
     # SCREENSHOTLOCATION="/storage/emulated/0/scripts/afk-arena/screen.png"
@@ -515,19 +517,46 @@ function challengeBoss() {
         input tap 550 1450
     fi
 
-    sleep 2
-    input tap 550 1850
-    sleep 1
-    input tap 80 1460
-    wait
-    input tap 230 960
-    sleep 1
+	# Finish battle if been 3 days
+	if [ "$forceFightCampaign" = "true" ]; then
+		battles=0
+		sleep 2
+		getColor 640 1330 # check for battle screen
+		while [ "$RGB" = "eacb95" ] && [ "$battles" -lt "$maxCampaignFights" ]; do
+			# Start battle
+			input tap 550 1850 # tap battle
+			# Wait until its over
+			waitBattleFinish 10
+			input tap 550 1720 # tap try again
+			wait
+			getColor 640 1330 # check for battle screen
+			let "battles++"
+		done
+			getColor 450 1775 # check if home
+			if [ "$RGB" != "cc9261" ]; then # not home
+				input tap 60 1850 # tap lower left arrow to exit
+				sleep 1
+				getColor 450 1775 # check if home
+				if [ "$RGB" != "cc9261" ]; then # not home
+					sleep 1
+					input tap 700 1260 # tap confirm
+				fi
+			fi
+	else # quick exit battle
+		sleep 2
+		input tap 550 1850 # tap battle
+		sleep 1
+		input tap 80 1460 # tap pause
+		wait
+		input tap 230 960 # tap exit
+		sleep 1
 
-    # Check for multi-battle
-    getColor 450 1775
-    if [ "$RGB" != "cc9261" ]; then
-        input tap 70 1810
-    fi
+		# Check for multi-battle
+		getColor 450 1775
+		if [ "$RGB" != "cc9261" ]; then
+			input tap 70 1810
+		fi
+	fi
 
     wait
     verifyRGB 450 1775 cc9261 "Challenged boss in campaign." "Failed to fight boss in Campaign."
@@ -1194,6 +1223,7 @@ function oakInn() {
 # test 410 1800 3 0.5 # Oak Inn Present Tab 2
 # test 550 1800 3 0.5 # Oak Inn Present Tab 3
 # test 690 1800 3 0.5 # Oak Inn Present Tab 4
+# test 640 1330 3 0.5 # yellow bg in battle screen
 
 # --- Script Start --- #
 echo "[INFO] Starting script... ($(date)) "

--- a/deploy.sh
+++ b/deploy.sh
@@ -266,13 +266,13 @@ function checkForDevice() {
 
 # Check date to decide whether to beat campaign or not.
 function checkDate() {
-	echo "in checkDate"
+    printTask "Checking last time script was run..."
 	if [ -f $tempFile ]; then
-		value=$(< $tempFile) # time of last beat campaign
-		now=$(date +"%s") # current time
-		let "difference = $now - $value" # time since last beat campaign
+		value=$(< $tempFile) # Time of last beat campaign
+		now=$(date +"%s") # Current time
+		let "difference = $now - $value" # Time since last beat campaign
 		
-		# if been longer than 3 days FIGHT
+		# If been longer than 3 days, set forceFightCampaign=true
 		if [ $difference -gt 255600 ]; then
 			forceFightCampaign=true
 		fi
@@ -305,7 +305,7 @@ function deploy() {
     $adb shell mkdir -p "$2"/scripts/afk-arena                # Create directories if they don't already exist
     $adb push afk-daily.sh "$2"/scripts/afk-arena 1>/dev/null # Push script to device
     $adb push config.sh "$2"/scripts/afk-arena 1>/dev/null    # Push config to device
-    $adb shell sh "$2"/scripts/afk-arena/afk-daily.sh "$2" "$forceFightCampaign" && saveDate && echo "Script finished!" # Run script. Comment line if you don't want to run the script after pushing
+    $adb shell sh "$2"/scripts/afk-arena/afk-daily.sh "$2" "$forceFightCampaign" && saveDate # Run script. Comment line if you don't want to run the script after pushing to device
 }
 
 # --- Script Start --- #

--- a/deploy.sh
+++ b/deploy.sh
@@ -282,7 +282,10 @@ function checkDate() {
 # Overwrite temp file with date if has been greater than 3 days or it doesn't exist
 function saveDate(){
 	if [ $forceFightCampaign == true ] || [ ! -f $tempFile ]; then
-		echo $(date +"%s") > .afkscript.tmp
+		echo $(date +"%s") > .afkscript.tmp # Write date to file
+
+        # Make file invisible if on windows
+        if [ "$OSTYPE" == "msys" ]; then attrib +h $tempFile; fi
 	fi
 }
 


### PR DESCRIPTION
Will beat the Campaign Every three days.
Waiting three days will give better rewards like mythic armor or upgrade stones, because of a pity timer.
Tested with single battles, multi-battles, edited temp file to be over 3 days, under 3 days. 