### PR TITLE
Add: Buy Elite Hero Soulstones #49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Custom
 .vscode
-config.sh
+config*.sh
 adb
 .markdownlint.json
 .afkscript.tmp

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ As of now, the script is capable of completing the following inside the game:
 - Strengthen the Resonating Crystal
 - Summon one Hero with Companion Points
 - Collect Oak Inn presents (necessary to enable "Hide Inn Heroes" in the game settings)
-- Collect daily Quest Chests
+- Collect daily and weekly quest chests
 - Collect Mail
 - Collect Daily/Weekly/Monthly rewards from Merchants
 
@@ -322,7 +322,7 @@ If you encounter an issue that is *not* listed above or in [issues](https://gith
 - [ ] Choose if you want to fight Wrizz/Soren or use Quick Battle
 - [x] Fight the twisted realm as well
 - [ ] Collect Soulstones
-- [ ] Collect weekly quests
+- [x] Collect weekly quests
 - [x] Collect Merchant Daily/Weekly/Monthly rewards (~~Will probably never happen if the games interface stays the same~~ Ended up happening!)
 - [x] Make script output pretty
 - [ ] Test for screen size with `adb shell wm size`

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ As of now, the script is capable of completing the following inside the game:
 - Send Heroes on Solo and Team Bounty Quests
 - Fight in the Arena of Heroes
 - Fight in the Legends Tournament
-- Fight in the Kings Tower
+- Fight in the available King's Towers
 - Fight Wrizz and Soren if available. Can also open Soren for you.
 - Fight in the Twisted Realm (necessary to have at least fought once against each TR boss for the game to save your formation)
 - Buy various items from the Store
@@ -318,7 +318,7 @@ If you encounter an issue that is *not* listed above or in [issues](https://gith
 
 - [x] Add some sort of config, ideally a `./deploy.sh config`
 - [x] Check if there are Bounty Quests to collect before sending out heroes on quests
-- [ ] Fight in more than just the main tower
+- [x] Fight in more than just the main tower
 - [ ] Choose if you want to fight Wrizz/Soren or use Quick Battle
 - [x] Fight the twisted realm as well
 - [ ] Collect Soulstones

--- a/README.md
+++ b/README.md
@@ -256,11 +256,12 @@ The script acts depending on a set of variables. In order to change these, open 
 
 ### Store
 
-| Variable           |   Type    | Description                                        | Default |
-| :----------------- | :-------: | :------------------------------------------------- | :-----: |
-| `buyStoreDust`     | `Boolean` | If `true`, buys Dust from the store for Gold.      | `true`  |
-| `buyStorePoeCoins` | `Boolean` | If `true`, buys Poe Coins from the store for Gold. | `true`  |
-| `buyStoreEmblems`  | `Boolean` | If `true`, buys Emblems from the store for Gold.   | `false` |
+| Variable               |   Type    | Description                                                         | Default |
+| :-----------------     | :-------: | :------------------------------------------------------------------ | :-----: |
+| `buyStoreDust`         | `Boolean` | If `true`, buys Dust from the store for Gold.                       | `true`  |
+| `buyStorePoeCoins`     | `Boolean` | If `true`, buys Poe Coins from the store for Gold.                  | `true`  |
+| `buyStoreEmblems`      | `Boolean` | If `true`, buys Emblems from the store for Gold.                    | `false` |
+| `buyStoreEliteStones`  | `Boolean` | If `true`, buys Elite Hero Soulstones from the store for 90 Gems.   | `false` |
 
 ### Campaign
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ The script acts depending on a set of variables. In order to change these, open 
 
 | Variable                    |   Type   | Description                                                                                                              | Default |
 | :-------------------------- | :------: | :----------------------------------------------------------------------------------------------------------------------- | :-----: |
-| `maxCampaignFights`         | `Number` | The total amount of attempts to fight in the campaign. Only losses count as attempts.                                    |  `10`   |
+| `maxCampaignFights`         | `Number` | The total amount of attempts to fight in the campaign. Only losses count as attempts.                                    |  `5`   |
+| `maxKingsTowerFights`       | `Number` | The total amount of attempts to fight in each King's Towers. Only losses count as attempts.                              |  `5`   |
 | `totalAmountArenaTries`     | `Number` | The total amount of tries the player may fight in the Arena. The minimum is always 2, that's why its displayed as `2+X`. |  `2+0`  |
 | `totalAmountGuildBossTries` | `Number` | The total amount of tries the player may fight a Guild Boss. The minimum is always 2, that's why its displayed as `2+X`. |  `2+0`  |
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <!-- <a href="#issues" alt="Script Status"><img src="https://img.shields.io/badge/Script-Partial-orange.svg"></img></a> -->
   <!-- <a href="#issues" alt="Script Status"><img src="https://img.shields.io/badge/Script-Failing-red.svg"></img></a> -->
   <!-- Latest patch -->
-  <a alt="Latest patch tested on"><img src="https://img.shields.io/badge/Patch-1.61.04-blue.svg"></img></a>
+  <a alt="Latest patch tested on"><img src="https://img.shields.io/badge/Patch-1.62.03-blue.svg"></img></a>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The script acts depending on a set of variables. In order to change these, open 
 | `doGuildHunts`            | `Boolean` | If `true`, fights Wrizz and possibly Soren.                                                                          | `true`  |
 | `doTwistedRealmBoss`      | `Boolean` | If `true`, fights current Twisted Realm Boss.                                                                        | `true`  |
 | `doBuyFromStore`          | `Boolean` | If `true`, buys items from store.                                                                                    | `true`  |
-| `doStrenghenCrystal`      | `Boolean` | If `true`, strengthens the resonating Crystal (without leveling up).                                                 | `true`  |
+| `doStrengthenCrystal`     | `Boolean` | If `true`, strengthens the resonating Crystal (without leveling up).                                                 | `true`  |
 | `doCompanionPointsSummon` | `Boolean` | If `true`, summons one hero with Companion Points.                                                                   | `false` |
 | `doCollectOakPresents`    | `Boolean` | **Only works if "Hide Inn Heroes" is enabled under "Settings -> Memory".** If `true`, collects Oak Inn red presents. | `false` |
 

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1236,7 +1236,7 @@ function buyFromStore() {
     # Elite Hero Soulstones
     if [ "$buyStoreEliteStones" == true ]; then
         getColor 410 850 # check top row, 2nd tile
-        if [ "$RGB" == "9787c9" ]; then
+        if [ "$RGB" == "9787c9" ] || [ "$RGB" == "998aca" ]; then
             buyStoreItem 410 850
             wait
         fi
@@ -1246,7 +1246,7 @@ function buyFromStore() {
             wait
         fi
         getColor 910 850 # check top row, 4th tile
-        if [ "$RGB" == "9f63d1" ] || [ "$RGB" == "a569d7" ] || [ "$RGB" == "a66ad7" ]; then 
+        if [ "$RGB" == "9f63d1" ] || [ "$RGB" == "a569d7" ] || [ "$RGB" == "a66ad7" ] || [ "$RGB" == "a266d4" ] || [ "$RGB" == "a468d5" ]; then 
             buyStoreItem 910 850
             wait
         fi
@@ -1488,7 +1488,7 @@ function oakInn() {
 }
 
 # Test function (X, Y, amountTimes, waitTime)
-# test 910 850 3 0.5
+test 910 850 3 0.5
 # test 550 740 3 0.5 # Check for Boss in Campaign
 # test 660 520 3 0.5 # Check for Solo Bounties RGB
 # test 650 570 3 0.5 # Check for Team Bounties RGB

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1246,7 +1246,7 @@ function buyFromStore() {
             wait
         fi
         getColor 910 850 # check top row, 4th tile
-        if [ "$RGB" == "9f63d1" ] || [ "$RGB" == "a569d7" ]; then 
+        if [ "$RGB" == "9f63d1" ] || [ "$RGB" == "a569d7" ] || [ "$RGB" == "a66ad7" ]; then 
             buyStoreItem 910 850
             wait
         fi

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1233,10 +1233,10 @@ function buyFromStore() {
         buyStoreItem 180 1430
         wait
     fi
-     # Elite Hero Soulstones
+    # Elite Hero Soulstones
     if [ "$buyStoreEliteStones" == true ]; then
         getColor 410 850 # check top row, 2nd tile
-        if [ "$RGB" == "9787c9" ]; then # tested twice, worked twice.
+        if [ "$RGB" == "9787c9" ]; then
             buyStoreItem 410 850
             wait
         fi
@@ -1246,7 +1246,7 @@ function buyFromStore() {
             wait
         fi
         getColor 910 850 # check top row, 4th tile
-        if [ "$RGB" == "a569d7" ]; then # tested once, worked once.
+        if [ "$RGB" == "9f63d1" ]; then 
             buyStoreItem 910 850
             wait
         fi
@@ -1488,7 +1488,7 @@ function oakInn() {
 }
 
 # Test function (X, Y, amountTimes, waitTime)
-# test 630 1520 3 0.5
+# test 910 850 3 0.5
 # test 550 740 3 0.5 # Check for Boss in Campaign
 # test 660 520 3 0.5 # Check for Solo Bounties RGB
 # test 650 570 3 0.5 # Check for Team Bounties RGB

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1246,7 +1246,7 @@ function buyFromStore() {
             wait
         fi
         getColor 910 850 # check top row, 4th tile
-        if [ "$RGB" == "9f63d1" ]; then 
+        if [ "$RGB" == "9f63d1" ] || [ "$RGB" == "a569d7" ]; then 
             buyStoreItem 910 850
             wait
         fi

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1233,6 +1233,24 @@ function buyFromStore() {
         buyStoreItem 180 1430
         wait
     fi
+     # Elite Hero Soulstones
+    if [ "$buyStoreEliteStones" == true ]; then
+        getColor 410 850 # check top row, 2nd tile
+        if [ "$RGB" == "9787c9" ]; then # tested twice, worked twice.
+            buyStoreItem 410 850
+            wait
+        fi
+        getColor 650 850 # check top row, 3rd tile
+        if [ "$RGB" == "544077" ]; then
+            buyStoreItem 650 850
+            wait
+        fi
+        getColor 910 850 # check top row, 4th tile
+        if [ "$RGB" == "a569d7" ]; then # tested once, worked once.
+            buyStoreItem 910 850
+            wait
+        fi
+    fi
     input tap 70 1810
 
     wait

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1242,10 +1242,10 @@ function buyFromStore() {
 # Collects
 function collectQuestChests() {
     # TODO: I think right here should be done a check for "some resources have exceeded their maximum limit". I have ascreenshot somewhere of this.
-    input tap 960 250
+    input tap 960 250 # Quests
     wait
 
-    # Collect Quests
+    # Collect daily Quests
     getColor 700 670
     while [ "$RGB" == "82fdf5" ]; do
         input tap 930 680
@@ -1253,26 +1253,58 @@ function collectQuestChests() {
         getColor 700 670
     done
 
-    input tap 330 430
+    # Collect daily Chests
+    input tap 330 430 # Chest 20
     wait
-    input tap 580 600
-    input tap 500 430
+    input tap 580 600 # Collect
+    input tap 500 430 # Chest 40
     wait
-    input tap 580 600
-    input tap 660 430
+    input tap 580 600 # Collect
+    input tap 660 430 # Chest 60
     wait
-    input tap 580 600
-    input tap 830 430
+    input tap 580 600 # Collect
+    input tap 830 430 # Chest 80
     wait
-    input tap 580 600
-    input tap 990 430
+    input tap 580 600 # Collect
+    input tap 990 430 # Chest 100
     wait
-    input tap 580 600
+    input tap 580 600 # Collect
     wait
-    input tap 70 1650
 
+    # Weekly quests
+    input tap 650 1650 # Weeklies
+    wait
+
+    # Collect weekly Quests
+    getColor 700 670
+    while [ "$RGB" == "82fdf5" ]; do
+        input tap 930 680
+        wait
+        getColor 700 670
+    done
+
+    # Collect weekly Chests
+    input tap 330 430 # Chest 20
+    wait
+    input tap 580 600 # Collect
+    input tap 500 430 # Chest 40
+    wait
+    input tap 580 600 # Collect
+    input tap 660 430 # Chest 60
+    wait
+    input tap 580 600 # Collect
+    input tap 830 430 # Chest 80
+    wait
+    input tap 580 600 # Collect
+    input tap 990 430 # Chest 100
+    wait
+    input tap 580 600 # Collect
+    wait
+
+    # Return
+    input tap 70 1650
     sleep 1
-    verifyRGB 20 1775 d49a61 "Collected daily quest chests." "Failed to collect daily quest chests."
+    verifyRGB 20 1775 d49a61 "Collected daily and weekly quest chests." "Failed to collect daily and weekly quest chests."
 }
 
 # Collects mail

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -744,16 +744,104 @@ function teamBounties() {
     verifyRGB 240 1775 d49a61 "Collected/dispatched team bounties." "Failed to collect/dispatch team bounties."
 }
 
+# Attempts to tap the closest Arena of Heroes opponent. Params: opponent
+function tapClosestOpponent() {
+    # Depending on the opponent number sent as a parameter ($1), this function
+    # would attempt to check if there's an opponent above the one sent.
+    # If there isn't, check the one above that one and so on until one is found.
+    # When found, tap on the opponent and exit function.
+    case $1 in
+    1)
+        # Refresh
+        input tap 815 540
+        sleep 2
+
+        # Attempt to fight $arenaHeroesOpponent opponent, and if not present, skip battle
+        case $arenaHeroesOpponent in
+        1)
+            # Check if opponent 1 exists and fight if true
+            getColor 820 700
+            if [ "$RGB" == "a7f1b7" ]; then input tap 820 700; else return 1; fi
+            ;;
+        2)
+            # Check if opponent 2 exists and fight if true
+            getColor 820 870
+            if [ "$RGB" == "2daab4" ] || [ "$RGB" == "aff3c0" ]; then input tap 820 870; else return 1; fi
+            ;;
+        3)
+            # Check if opponent 3 exists and fight if true
+            getColor 820 1050
+            if [ "$RGB" == "a7f1b7" ]; then input tap 820 1050; else return 1; fi
+            ;;
+        4)
+            # Check if opponent 4 exists and fight if true
+            getColor 820 1220
+            if [ "$RGB" == "2daab4" ] || [ "$RGB" == "aff3c0" ]; then input tap 820 1220; else return 1; fi
+            ;;
+        5)
+            # Check if opponent 5 exists and fight if true
+            getColor 820 1400
+            if [ "$RGB" == "aaf2bb" ]; then input tap 820 1400; else return 1; fi
+            ;;
+        esac
+        ;;
+    2)
+        # Check if opponent 1 exists
+        getColor 820 700
+        if [ "$RGB" == "a7f1b7" ]; then
+            # Fight opponent
+            input tap 820 700
+        else
+            # Try to fight the closest opponent to 2
+            tapClosestOpponent 1
+        fi
+        ;;
+    3)
+        # Check if opponent 2 exists
+        getColor 820 870
+        if [ "$RGB" == "2daab4" ] || [ "$RGB" == "aff3c0" ]; then
+            # Fight opponent
+            input tap 820 870
+        else
+            # Try to fight the closest opponent to 3
+            tapClosestOpponent 2
+        fi
+        ;;
+    4)
+        # Check if opponent 3 exists
+        getColor 820 1050
+        if [ "$RGB" == "a7f1b7" ]; then
+            # Fight opponent
+            input tap 820 1050
+        else
+            # Try to fight the closest opponent to 4
+            tapClosestOpponent 3
+        fi
+        ;;
+    5)
+        # Check if opponent 4 exists
+        getColor 820 1220
+        if [ "$RGB" == "2daab4" ] || [ "$RGB" == "aff3c0" ]; then
+            # Fight opponent
+            input tap 820 1220
+        else
+            # Try to fight the closest opponent to 5
+            tapClosestOpponent 4
+        fi
+        ;;
+    esac
+}
+
 # Does the daily arena of heroes battles
 function arenaOfHeroes() {
     input tap 740 1050
-    sleep 2
+    sleep 3
     if [ "$pvpEvent" == false ]; then
         input tap 550 450
     else
         input tap 550 900
     fi
-    sleep 2
+    sleep 3
     input tap 1000 1800
     wait
     input tap 980 410
@@ -770,33 +858,84 @@ function arenaOfHeroes() {
             # Refresh
             # input tap 815 540
             # wait
+
             # Fight specific opponent
+            #                                Free         x1
+            #  Opponent 1: 820 700      ->        a7f1b7
+            #  Opponent 2: 820 870      ->  2eaab4      aff3c0
+            #  Opponent 3: 820 1050     ->        a7f1b7
+            #  Opponent 4: 820 1220     ->  2daab4      aff3c0
+            #  Opponent 5: 820 1400     ->        aaf2bb
             case $arenaHeroesOpponent in
             1)
-                input tap 820 700
+                # Check if opponent exists
+                getColor 820 700
+                if [ "$RGB" == "a7f1b7" ]; then
+                    # Fight opponent
+                    input tap 820 700
+                else
+                    # Refresh opponents and try to fight opponent $arenaHeroesOpponent
+                    tapClosestOpponent 1
+                fi
                 ;;
             2)
-                input tap 820 870
+                # Check if opponent exists
+                getColor 820 870
+                if [ "$RGB" == "2daab4" ] || [ "$RGB" == "aff3c0" ]; then
+                    # Fight opponent
+                    input tap 820 870
+                else
+                    # Try to fight the closest opponent to 2
+                    tapClosestOpponent 2
+                fi
                 ;;
             3)
-                input tap 820 1050
+                # Check if opponent exists
+                getColor 820 1050
+                if [ "$RGB" == "a7f1b7" ]; then
+                    # Fight opponent
+                    input tap 820 1050
+                else
+                    # Try to fight the closest opponent to 3
+                    tapClosestOpponent 3
+                fi
                 ;;
             4)
-                input tap 820 1220
+                # Check if opponent exists
+                getColor 820 1220
+                if [ "$RGB" == "2daab4" ] || [ "$RGB" == "aff3c0" ]; then
+                    # Fight opponent
+                    input tap 820 1220
+                else
+                    # Try to fight the closest opponent to 4
+                    tapClosestOpponent 4
+                fi
                 ;;
             5)
-                input tap 820 1400
+                # Check if opponent exists
+                getColor 820 1400
+                if [ "$RGB" == "aaf2bb" ]; then
+                    # Fight opponent
+                    input tap 820 1400
+                else
+                    # Try to fight the closest opponent to 5
+                    tapClosestOpponent 5
+                fi
                 ;;
             esac
-            sleep 2
-            input tap 550 1850
-            waitBattleFinish 2
-            if [ "$battleFailed" == false ]; then
-                input tap 550 1550 # Collect
+
+            # Check if return value of tapClosesopponent is 0. If it is 0, then it means a battle has been found.
+            if [ $? == 0 ]; then
                 sleep 2
+                input tap 550 1850 # Battle
+                waitBattleFinish 2
+                if [ "$battleFailed" == false ]; then
+                    input tap 550 1550 # Collect
+                    sleep 2
+                fi
+                input tap 550 1550 # Finish battle
+                sleep 3
             fi
-            input tap 550 1550 # Finish battle
-            sleep 3
             ((COUNT = COUNT + 1)) # Increment
         done
 
@@ -1149,7 +1288,7 @@ function collectMerchants() {
 }
 
 # If red square, strenghen Crystal
-function strenghenCrystal() {
+function strengthenCrystal() {
     input tap 760 1030 # Crystal
     sleep 3
 
@@ -1325,7 +1464,7 @@ if [ "$doTwistedRealmBoss" == true ]; then
     if [ "$doGuildHunts" == true ]; then twistedRealmBoss; else twistedRealmBoss true; fi
 fi
 if [ "$doBuyFromStore" == true ]; then buyFromStore; fi
-if [ "$doStrenghenCrystal" == true ]; then strenghenCrystal; fi
+if [ "$doStrengthenCrystal" == true ]; then strengthenCrystal; fi
 if [ "$doCompanionPointsSummon" == true ]; then nobleTavern; fi
 if [ "$doCollectOakPresents" == true ]; then oakInn; fi
 

--- a/afk-daily.sh
+++ b/afk-daily.sh
@@ -1009,24 +1009,76 @@ function legendsTournament() {
     verifyRGB 240 1775 d49a61 "Battled at the Legends Tournament." "Failed to battle at the Legends Tournament."
 }
 
+# Battles in King's Towers. Params: X, Y
+function battleKingsTower() {
+    local COUNT=0
+    input tap $1 $2 # Tap chosen tower
+    sleep 2
+
+    # Check if inside tower
+    getColor 550 150
+    if [ "$RGB" == "1a1212" ]; then
+        input tap 540 1350 # Challenge
+        wait
+
+        # Battle while less than maxKingsTowerFights & we haven't reached daily limit of 10 floors
+        getColor 550 150
+        while [ "$COUNT" -lt "$maxKingsTowerFights" ] && [ "$RGB" != "1a1212" ]; do
+            input tap 550 1850 # Battle
+            waitBattleFinish 2
+
+            # Check if win or lose battle
+            if [ "$battleFailed" == false ]; then
+                input tap 550 1850 # Collect
+                sleep 4
+
+                # TODO: Limited offers might screw this up though I'm not sure they actually spawn in here, maybe only at the main tabs
+                # Tap top of the screen to close any possible Limited Offers
+                # getColor 550 150
+                # if [ "$RGB" != "1a1212" ]; then # not on screen with Challenge button
+                #     input tap 550 75 # Tap top of the screen to close Limited Offer
+                #     wait
+                #     getColor 550 150
+                #     if [ "$RGB" != "1a1212" ]; then # think i remember it needs two taps to close offer
+                #         input tap 550 75 # Tap top of the screen to close Limited Offer
+                #         wait
+                # fi
+
+                input tap 540 1350 # Challenge
+                sleep 2
+            elif [ "$battleFailed" == true ]; then
+                input tap 550 1720    # Try again
+                ((COUNT = COUNT + 1)) # Increment
+                wait
+            fi
+
+            # Check if reached daily limit / kicked us out of battle screen
+            getColor 550 150
+        done
+
+        # Return from chosen tower / battle
+        input tap 70 1810
+        sleep 3
+        getColor 550 150
+        if [ "$RGB" = "1a1212" ]; then input tap 70 1810; fi # In case still in tower, exit once more
+        sleep 2
+    fi
+}
+
 # Battles once in the kings tower
 function kingsTower() {
-    input tap 500 870
+    input tap 500 870 # King's Tower
     sleep 2
-    input tap 550 900
-    sleep 2
-    input tap 540 1350
-    sleep 2
-    input tap 550 1850
-    sleep 2
-    input tap 80 1460
-    sleep 1
-    input tap 230 960
-    wait
-    input tap 70 1810
-    wait
-    input tap 70 1810
 
+    # Towers
+    battleKingsTower 550 900  # Main Tower
+    battleKingsTower 250 500  # Tower of Light
+    battleKingsTower 800 500  # The Brutal Citadel
+    battleKingsTower 250 1400 # The World Tree
+    battleKingsTower 800 1400 # The Forsaken Necropolis
+
+    # Exit
+    input tap 70 1810
     wait
     verifyRGB 240 1775 d49a61 "Battled at the Kings Tower." "Failed to battle at the Kings Tower."
 }
@@ -1386,7 +1438,7 @@ function oakInn() {
 }
 
 # Test function (X, Y, amountTimes, waitTime)
-# test 560 350 3 0.5
+# test 630 1520 3 0.5
 # test 550 740 3 0.5 # Check for Boss in Campaign
 # test 660 520 3 0.5 # Check for Solo Bounties RGB
 # test 650 570 3 0.5 # Check for Team Bounties RGB

--- a/deploy.sh
+++ b/deploy.sh
@@ -111,6 +111,7 @@ totalAmountGuildBossTries=2+0
 buyStoreDust=true
 buyStorePoeCoins=true
 buyStoreEmblems=false
+buyStoreEliteStones=false
 
 # --- Actions --- #
 # Campaign
@@ -163,6 +164,7 @@ function validateConfig() {
         $buyStoreDust || -z \
         $buyStorePoeCoins || -z \
         $buyStoreEmblems || -z \
+        $buyStoreEliteStones || -z \
         $doLootAfkChest || -z \
         $doChallengeBoss || -z \
         $doFastRewards || -z \

--- a/deploy.sh
+++ b/deploy.sh
@@ -102,7 +102,8 @@ waitForUpdate=true
 endAt="championship"
 
 # Repetitions
-maxCampaignFights=10
+maxCampaignFights=5
+maxKingsTowerFights=5
 totalAmountArenaTries=2+0
 totalAmountGuildBossTries=2+0
 
@@ -156,6 +157,7 @@ function validateConfig() {
         $waitForUpdate || -z \
         $endAt || -z \
         $maxCampaignFights || -z \
+        $maxKingsTowerFights || -z \
         $totalAmountArenaTries || -z \
         $totalAmountGuildBossTries || -z \
         $buyStoreDust || -z \
@@ -312,7 +314,7 @@ function deploy() {
 clear
 
 checkAdb
-checkForUpdate
+#checkForUpdate
 checkConfig
 checkLineEndings "config.sh"
 checkLineEndings "afk-daily.sh"

--- a/deploy.sh
+++ b/deploy.sh
@@ -129,7 +129,7 @@ doKingsTower=true
 doGuildHunts=true
 doTwistedRealmBoss=true
 doBuyFromStore=true
-doStrenghenCrystal=true
+doStrengthenCrystal=true
 doCompanionPointsSummon=false
 doCollectOakPresents=false # Only works if "Hide Inn Heroes" is enabled under "Settings -> Memory"
 
@@ -173,7 +173,7 @@ function validateConfig() {
         $doGuildHunts || -z \
         $doTwistedRealmBoss || -z \
         $doBuyFromStore || -z \
-        $doStrenghenCrystal || -z \
+        $doStrengthenCrystal || -z \
         $doCompanionPointsSummon || -z \
         $doCollectOakPresents || -z \
         $doCollectQuestChests || -z \
@@ -267,26 +267,26 @@ function checkForDevice() {
 # Check date to decide whether to beat campaign or not.
 function checkDate() {
     printTask "Checking last time script was run..."
-	if [ -f $tempFile ]; then
-		value=$(< $tempFile) # Time of last beat campaign
-		now=$(date +"%s") # Current time
-		let "difference = $now - $value" # Time since last beat campaign
-		
-		# If been longer than 3 days, set forceFightCampaign=true
-		if [ $difference -gt 255600 ]; then
-			forceFightCampaign=true
-		fi
-	fi
+    if [ -f $tempFile ]; then
+        value=$(< $tempFile) # Time of last beat campaign
+        now=$(date +"%s") # Current time
+        let "difference = $now - $value" # Time since last beat campaign
+
+        # If been longer than 3 days, set forceFightCampaign=true
+        if [ $difference -gt 255600 ]; then
+            forceFightCampaign=true
+        fi
+    fi
 }
 
 # Overwrite temp file with date if has been greater than 3 days or it doesn't exist
 function saveDate(){
-	if [ $forceFightCampaign == true ] || [ ! -f $tempFile ]; then
-		echo $(date +"%s") > .afkscript.tmp # Write date to file
+    if [ $forceFightCampaign == true ] || [ ! -f $tempFile ]; then
+        echo $(date +"%s") > .afkscript.tmp # Write date to file
 
         # Make file invisible if on windows
         if [ "$OSTYPE" == "msys" ]; then attrib +h $tempFile; fi
-	fi
+    fi
 }
 
 # Makes a Dir (if it doesn't exist), pushes script into Dir, Executes script in Dir.


### PR DESCRIPTION
Discussion Forum: #49

Probably need a few more rounds of testing the RGBs, since I got different values a few times on the 4th tile. The last RGB I got from the 4th tile worked, and the script **did** buy the soulstones.

I edited the script so it only buys store items then exits, for testing.

* Add: Buy Elite Hero Soulstones

* Add: buyStoreEliteStones to config.sh

* Add: buyStoreEliteStones to README.md