### PR TITLE
Fix: Create flag to not check restart ADB and check for device #85

### DIFF
--- a/.wiki/Usage.md
+++ b/.wiki/Usage.md
@@ -32,7 +32,7 @@ OPTIONS
 
    -d, --device [DEVICE]
       Specify target device.
-      Values for [DEVICE]: bs (default), dev, nox, memu
+      Values for [DEVICE]: bs (default), nox, memu
 
    -e, --event [EVENT]
       Specify active event.
@@ -58,6 +58,9 @@ OPTIONS
       Force weekly.
 
 DEV OPTIONS
+
+   -b
+      Dev mode: do not restart adb.
 
    -c, --check
       Check if script is ready to be run.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
    </a>
 
    <!-- Badges -->
-   <a alt="Script version"><img src="https://img.shields.io/badge/Version-2.0.2-blue"></img></a>
+   <a alt="Script version"><img src="https://img.shields.io/badge/Version-2.1.0-blue"></img></a>
    <a alt="Latest AFK Arena patch tested on"><img src="https://img.shields.io/badge/Patch-1.71.03-blue"></img></a>
    <a alt="Language" href="https://www.gnu.org/software/bash/"><img src="https://img.shields.io/badge/Language-Shell-yellow?logo=gnu-bash&logoColor=yellow"></img></a>
    <a alt="Discord" href="https://discord.gg/Fq2cfqjp8D"><img src="https://img.shields.io/discord/859136061049143307?label=Discord&logo=discord"></img></a>

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,6 +32,7 @@ evt="" # Default dev evt
 
 # Do not modify
 adb=adb
+devMode=false
 forceFightCampaign=false
 forceWeekly=false
 ignoreResolution=false
@@ -554,20 +555,19 @@ run() {
     check_all
     getLatestPatch
 
-    if [ "$device" == "Bluestacks" ]; then
+    if [ "$devMode" = false ]; then
         restartAdb
+    fi
+
+    if [ "$device" == "Bluestacks" ]; then
         checkDevice "Bluestacks"
         deploy "Bluestacks" "$bluestacksDirectory"
     elif [ "$device" == "Memu" ]; then
-        restartAdb
         checkDevice "Memu"
         deploy "Memu" "$memuDirectory"
     elif [ "$device" == "Nox" ]; then
-        restartAdb
         checkDevice "Nox"
         deploy "Nox" "$noxDirectory"
-    elif [ "$device" == "dev" ]; then
-        checkDevice
     else
         restartAdb
         checkDevice
@@ -601,7 +601,7 @@ show_help() {
     echo -e
     echo -e "   ${cCyan}-d${cWhite}, ${cCyan}--device${cWhite} ${cGreen}[DEVICE]${cWhite}"
     echo -e "      Specify target device."
-    echo -e "      Values for ${cGreen}[DEVICE]${cWhite}: bs (default), dev, nox, memu"
+    echo -e "      Values for ${cGreen}[DEVICE]${cWhite}: bs (default), nox, memu"
     echo -e
     echo -e "   ${cCyan}-e${cWhite}, ${cCyan}--event${cWhite} ${cGreen}[EVENT]${cWhite}"
     echo -e "      Specify active event."
@@ -627,6 +627,9 @@ show_help() {
     echo -e "      Force weekly."
     echo -e
     echo -e "DEV OPTIONS"
+    echo -e
+    echo -e "   ${cCyan}-b${cWhite}"
+    echo -e "      Dev mode: do not restart adb."
     echo -e
     echo -e "   ${cCyan}-c${cWhite}, ${cCyan}--check${cWhite}"
     echo -e "      Check if script is ready to be run."
@@ -691,10 +694,13 @@ for arg in "$@"; do
     esac
 done
 
-while getopts ":a:cd:e:fhi:no:rs:tv:w" option; do
+while getopts ":ab:cd:e:fhi:no:rs:tv:w" option; do
     case $option in
     a)
         tempFile="account-info/acc-${OPTARG}.ini"
+        ;;
+    b)
+        devMode=true
         ;;
     c)
         check_all
@@ -712,8 +718,6 @@ while getopts ":a:cd:e:fhi:no:rs:tv:w" option; do
                 printError "nox_adb.exe not found, please check your Nox settings"
                 exit 1
             fi
-        elif [ "$OPTARG" == "dev" ]; then
-            device="dev"
         fi
         ;;
     e)

--- a/deploy.sh
+++ b/deploy.sh
@@ -694,7 +694,7 @@ for arg in "$@"; do
     esac
 done
 
-while getopts ":ab:cd:e:fhi:no:rs:tv:w" option; do
+while getopts ":a:bcd:e:fhi:no:rs:tv:w" option; do
     case $option in
     a)
         tempFile="account-info/acc-${OPTARG}.ini"


### PR DESCRIPTION
I did just remove restart ADB at the moment, may also remove check, was just more boring to do 😉 